### PR TITLE
fix: aldryn config parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,9 @@ Changelog
 
 1.0.1 (unreleased)
 ==================
+
 * Removed internal ``DEFAULT_CHOICE`` variable
+* Fixed faulty settings parsing in aldryn_config.py
 
 
 1.0.0 (2016-29-08)

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -2,6 +2,10 @@
 from aldryn_client import forms
 
 
+def split_and_strip(string):
+    return [item.strip() for item in string.split(',') if item]
+
+
 class Form(forms.BaseForm):
     templates = forms.CharField(
         'List of additional templates (comma separated)',
@@ -15,17 +19,28 @@ class Form(forms.BaseForm):
     def clean(self):
         data = super(Form, self).clean()
 
-        def split_and_strip(string):
-            return [item.strip() for item in string.split(',') if item]
+        # older versions of this addon had a bug where the values would be
+        # saved to settings.json as a list instead of a string.
+        if isinstance(data['templates'], list):
+            data['templates'] = ', '.join(data['templates'])
+        if isinstance(data['extensions'], list):
+            data['extensions'] = ', '.join(data['extensions'])
 
-        data['templates'] = split_and_strip(data['templates'])
-        data['extensions'] = split_and_strip(data['extensions'])
+        # prettify
+        data['templates'] = ', '.join(split_and_strip(data['templates']))
+        data['extensions'] = ', '.join(split_and_strip(data['extensions']))
         return data
 
     def to_settings(self, data, settings):
-        # validate aldryn settings
         if data['templates']:
-            settings['DJANGOCMS_AUDIO_TEMPLATES'] = [(item, item) for item in data['templates']]
+            settings['DJANGOCMS_AUDIO_TEMPLATES'] = [
+                (item, item)
+                for item in split_and_strip(data['templates'])
+            ]
         if data['extensions']:
-            settings['DJANGOCMS_AUDIO_ALLOWED_EXTENSIONS'] = data['extensions']
+            settings['DJANGOCMS_AUDIO_ALLOWED_EXTENSIONS'] = split_and_strip(data['extensions'])
+
+        from pprint import pprint as pp
+        pp(data)
+        pp(settings)
         return settings


### PR DESCRIPTION
The result of clean gets used to display forms as well, so it would end
up with a string-ification of the values after clean
(``"[u'item1', u'item2']"``) instead of the string with commas.

The new implementation cleans the comma separated items to always have
a space after the comma. Conversion to an actual python list happens
while generating the settings.