### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-1.0.1 (unreleased)
+1.0.1 (2016-09-08)
 ==================
 
 * Removed internal ``DEFAULT_CHOICE`` variable

--- a/djangocms_audio/__init__.py
+++ b/djangocms_audio/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.0.0'
+__version__ = '1.0.1'


### PR DESCRIPTION
* Removed internal ``DEFAULT_CHOICE`` variable
* Removed ``base.html`` for performance reasons
* Fixed faulty settings parsing in aldryn_config.py
* Fixed typo in aldryn configuration
* Adapted private ``get_template`` method
* Updated translations
