### PR TITLE
adapted testing infrastructure, migrations and naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ env:
   - TOX_ENV=py27-latest
   - TOX_ENV=py34-latest
   # Django 1.8
-  - TOX_ENV=py34-dj18-cms33
-  - TOX_ENV=py34-dj18-cms32
+  - TOX_ENV=py27-dj18-cms34
   - TOX_ENV=py27-dj18-cms33
-  - TOX_ENV=py27-dj18-cms32
+  - TOX_ENV=py34-dj18-cms34
+  - TOX_ENV=py34-dj18-cms33
   # Django 1.9
-  - TOX_ENV=py34-dj19-cms33
-  - TOX_ENV=py34-dj19-cms32
+  - TOX_ENV=py27-dj19-cms34
   - TOX_ENV=py27-dj19-cms33
-  - TOX_ENV=py27-dj19-cms32
+  - TOX_ENV=py34-dj19-cms34
+  - TOX_ENV=py34-dj19-cms33
 
 install:
   - pip install tox coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ Changelog
 =========
 
 
+1.0.2 (unreleased)
+==================
+* Prevent changes to ``DJANGOCMS_AUDIO_XXX`` settings from requiring new
+  migrations
+* Changed naming of ``Aldryn`` to ``Divio Cloud``
+* Adapted testing infrastructure (tox/travis) to incorporate
+  django CMS 3.4 and dropped 3.2
+
+
 1.0.1 (2016-08-09)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ but you can override this in your own templates if required).
 It uses files managed by `Django Filer <https://github.com/divio/django-filer>`_.
 The plugins allow you to select a single file or an entire folder of files.
 
-This addon is compatible with `Aldryn <http://aldryn.com>`_ and is also available on the
+This addon is compatible with `Divio Cloud <http://divio.com>`_ and is also available on the
 `django CMS Marketplace <https://marketplace.django-cms.org/en/addons/browse/djangocms-googlemap/>`_
 for easy installation.
 

--- a/djangocms_audio/migrations/0002_auto_20160825_1821.py
+++ b/djangocms_audio/migrations/0002_auto_20160825_1821.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
+from djangocms_audio.models import get_templates
 
 
 class Migration(migrations.Migration):
@@ -24,7 +25,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='audioplayer',
             name='template',
-            field=models.CharField(default='default', max_length=255, verbose_name='Template', choices=[('default', 'Default')]),
+            field=models.CharField(default=get_templates()[0][0], max_length=255, verbose_name='Template', choices=get_templates()),
         ),
         migrations.AlterField(
             model_name='audiotrack',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     py{34,27}-latest
-    py{34,27}-dj18-cms{33,32}
-    py{34,27}-dj19-cms{33,32}
+    py{34,27}-dj18-cms{34,33}
+    py{34,27}-dj19-cms{34,33}
 
 skip_missing_interpreters=True
 
@@ -14,8 +14,8 @@ deps =
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     latest: django-cms
-    cms32: django-cms>=3.2,<3.3
     cms33: django-cms>=3.3,<3.4
+    cms34: django-cms>=3.4,<3.5
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
* Prevent changes to ``DJANGOCMS_AUDIO_XXX`` settings from requiring new
  migrations
* Changed naming of ``Aldryn`` to ``Divio Cloud``
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.4 and dropped 3.2