### PR TITLE
Release version 1.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-1.0.2 (unreleased)
+1.0.2 (2016-11-22)
 ==================
 * Prevent changes to ``DJANGOCMS_AUDIO_XXX`` settings from requiring new
   migrations

--- a/djangocms_audio/__init__.py
+++ b/djangocms_audio/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.0.1'
+__version__ = '1.0.2'


### PR DESCRIPTION
* Prevent changes to ``DJANGOCMS_AUDIO_XXX`` settings from requiring new
  migrations
* Changed naming of ``Aldryn`` to ``Divio Cloud``
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.4 and dropped 3.2