### PR TITLE
initial Django 2.0 support

### DIFF
--- a/djangocms_audio/migrations/0001_initial.py
+++ b/djangocms_audio/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='AudioFile',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_audio_audiofile', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_audio_audiofile', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('text_title', models.CharField(max_length=200, verbose_name='Title', blank=True)),
                 ('text_description', models.TextField(verbose_name='Description', blank=True)),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, verbose_name='Attributes', blank=True)),
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='AudioFolder',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_audio_audiofolder', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_audio_audiofolder', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, help_text='Is applied to all audio file instances.', verbose_name='Attributes', blank=True)),
                 ('audio_folder', filer.fields.folder.FilerFolderField(related_name='+', on_delete=django.db.models.deletion.SET_NULL, verbose_name='Folder', to='filer.Folder', null=True)),
             ],
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='AudioPlayer',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_audio_audioplayer', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_audio_audioplayer', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('template', models.CharField(default=b'default', max_length=50, verbose_name='Template', choices=[(b'default', 'Default')])),
                 ('label', models.CharField(max_length=200, verbose_name='Label', blank=True)),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, verbose_name='Attributes', blank=True)),
@@ -58,7 +58,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='AudioTrack',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_audio_audiotrack', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_audio_audiotrack', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('kind', models.CharField(max_length=50, verbose_name='Kind', choices=[(b'subtitles', 'Subtitles'), (b'captions', 'Captions'), (b'descriptions', 'Descriptions'), (b'chapters', 'Chapters')])),
                 ('srclang', models.CharField(help_text='Examples: "en" or "de" etc.', max_length=10, verbose_name='Source language', blank=True)),
                 ('label', models.CharField(max_length=200, verbose_name='Label', blank=True)),


### PR DESCRIPTION
Squashing some incompatibilities between Django 1.11 and 2.0.

django-cms is not Django 2.0 ready yet, but I'm trying to get various plugins and dependencies compatible to make it easier for the whole ecosystem to work on 2.0.x eventually.