### PR TITLE
Bumped version to 1.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-1.2.0 (unreleased)
+1.2.0 (2019-05-22)
 ==================
 
 * Added support for Django 2.2 and django CMS 3.7

--- a/djangocms_audio/__init__.py
+++ b/djangocms_audio/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.1.0'
+__version__ = '1.2.0'


### PR DESCRIPTION
* Added support for Django 2.2 and django CMS 3.7
* Removed support for Django 2.0
* Extended test matrix
* Fixed typo in ``MANIFEST.in``
* Added isort and adapted imports
* Adapted code base to align with other supported addons
